### PR TITLE
Align package metadata with 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Migration
 - FLoRa-aligned scenarios now inject the historical inter-SF capture matrix and lock the 6-symbol capture window automatically. Remove any custom `orthogonal_sf`/`non_orth_matrix` overrides and rely on the default behaviour when migrating configurations. The new `--long-range-demo very_long_range` preset replaces manual tuning for 15 km studies.
 
+## [1.0.1] - 2025-08-27
+### Fixed
+- Align package metadata version with the README to publish release 1.0.1 consistently.
+
 ## [5.0] - 2025-07-24
 ### Added
 - Complete rewrite of the LoRa network simulator in Python.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "LoRaFlexSim"
-version = "1.0.0"
+version = "1.0.1"
 # Updated name to reflect new project identity
 description = "LoRaFlexSim : simulateur complet et flexible de réseau LoRa"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- update the project version in `pyproject.toml` to 1.0.1 so packaging matches the README
- add a 1.0.1 entry to the changelog documenting the metadata alignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc00ca98fc83319ea5689e6908b631