### PR TITLE
Corrige une faute de frappe dans un commentaire

### DIFF
--- a/loraflexsim/launcher/simulator.py
+++ b/loraflexsim/launcher/simulator.py
@@ -1518,7 +1518,7 @@ class Simulator:
                 break
             # Replanifier selon la classe du nœud
             if node.class_type.upper() == "C":
-                # Classe C : ne reprogamme la fenêtre périodique que si un
+                # Classe C : ne reprogramme la fenêtre périodique que si un
                 # downlink reste à livrer ou si le nœud n'a pas encore atteint
                 # son quota ``packets_to_send``. Cela évite de maintenir un
                 # polling infini une fois la simulation terminée tout en


### PR DESCRIPTION
## Summary
- corrige une faute de frappe dans un commentaire de la classe C dans `simulator.py`

## Testing
- pytest tests/test_class_c_fast_forward.py

------
https://chatgpt.com/codex/tasks/task_e_68dc03e9844483319ce18e7194d91365