### PR TITLE
Fix battery tracking scripts and RX ramp accounting

### DIFF
--- a/loraflexsim/launcher/node.py
+++ b/loraflexsim/launcher/node.py
@@ -447,7 +447,7 @@ class Node:
             preamble = self.profile.energy_for(
                 "preamble", self.profile.preamble_time_s
             )
-        elif state_key == "rx":
+        elif state_key in {"rx", "listen"}:
             ramp_duration = self.profile.ramp_up_s + self.profile.ramp_down_s
             if ramp_duration > 0.0:
                 ramp = self.profile.energy_for("ramp", ramp_duration)

--- a/scripts/plot_battery_tracking.py
+++ b/scripts/plot_battery_tracking.py
@@ -97,7 +97,9 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         metavar="NODE",
         help="Identifiant de nœud à mettre en évidence (peut être répété ou séparé par des virgules)",
     )
-    return parser.parse_args(argv)
+    if argv is None:
+        argv = []
+    return parser.parse_args(list(argv))
 
 
 def main(argv: Sequence[str] | None = None) -> None:

--- a/scripts/run_battery_tracking.py
+++ b/scripts/run_battery_tracking.py
@@ -9,6 +9,11 @@ can be executed to gather statistics across runs.
 Usage::
 
     python scripts/run_battery_tracking.py --nodes 5 --packets 3 --seed 1 --replicates 2
+
+Le trafic est périodique (intervalle de 1 seconde), sans mobilité et avec
+une seule passerelle par défaut afin de garantir des mesures reproductibles.
+Les options ``--transmission-mode``, ``--packet-interval``, ``--mobility`` et
+``--gateways`` permettent de personnaliser ces paramètres si nécessaire.
 """
 
 from __future__ import annotations
@@ -73,6 +78,29 @@ def main() -> None:
         help="Number of simulation replicates",
     )
     parser.add_argument(
+        "--gateways",
+        type=int,
+        default=1,
+        help="Nombre de passerelles dans la simulation",
+    )
+    parser.add_argument(
+        "--transmission-mode",
+        default="Periodic",
+        help="Mode de transmission (ex. Periodic, Random)",
+    )
+    parser.add_argument(
+        "--packet-interval",
+        type=float,
+        default=1.0,
+        help="Intervalle moyen entre paquets (s)",
+    )
+    parser.add_argument(
+        "--mobility",
+        action="store_true",
+        default=False,
+        help="Active la mobilité aléatoire des nœuds",
+    )
+    parser.add_argument(
         "--battery-capacity-j",
         type=float,
         default=DEFAULT_BATTERY_J,
@@ -124,9 +152,13 @@ def main() -> None:
     for rep in range(args.replicates):
         sim = Simulator(
             num_nodes=args.nodes,
+            num_gateways=args.gateways,
             packets_to_send=args.packets,
             seed=args.seed + rep,
             battery_capacity_j=args.battery_capacity_j,
+            transmission_mode=args.transmission_mode,
+            packet_interval=args.packet_interval,
+            mobility=args.mobility,
         )
 
         monitored_nodes = list(sim.nodes)


### PR DESCRIPTION
## Summary
- ensure ramp energy is accounted for during listen phases and when RX windows are fast-forwarded
- make the battery tracking CLI deterministic by default with optional transmission and mobility overrides
- make the plotting script ignore inherited argv when invoked as a library

## Testing
- pytest tests/test_energy_accounting.py -vv
- pytest tests/test_battery_depletion_cli.py::test_battery_tracking_stops_on_depletion -vv
- pytest tests/test_battery_tracking_script.py::test_battery_tracking_script -vv

------
https://chatgpt.com/codex/tasks/task_e_68dc0ff128ec83319ea5dbc460fba193