### PR TITLE
Remove figure titles from article A plotting scripts

### DIFF
--- a/scripts/mne3sd/article_a/plots/plot_class_density_metrics.py
+++ b/scripts/mne3sd/article_a/plots/plot_class_density_metrics.py
@@ -120,7 +120,6 @@ def plot_pdr_vs_nodes(df: pd.DataFrame) -> None:
 
     ax.set_xlabel("Number of nodes")
     ax.set_ylabel("Packet delivery ratio (%)")
-    ax.set_title("Packet delivery ratio versus node density")
     ax.set_ylim(0, 105)
     ax.legend(title="Class")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.6)
@@ -159,7 +158,6 @@ def plot_energy_vs_nodes(df: pd.DataFrame) -> bool:
 
     ax.set_xlabel("Number of nodes")
     ax.set_ylabel("Energy per node (J)")
-    ax.set_title("Energy consumption versus node density")
     ax.legend(title="Class")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.6)
     fig.tight_layout()

--- a/scripts/mne3sd/article_a/plots/plot_class_downlink_energy.py
+++ b/scripts/mne3sd/article_a/plots/plot_class_downlink_energy.py
@@ -117,8 +117,8 @@ def plot_energy_breakdown(
 
     ax.set_xticks(indices)
     ax.set_xticklabels([f"Class {name}" for name in classes])
+    ax.set_xlabel("LoRaWAN class")
     ax.set_ylabel("Average energy per node (J)")
-    ax.set_title("Energy breakdown by class")
     ax.grid(True, axis="y", linestyle="--", linewidth=0.5, alpha=0.6)
     ax.legend()
     fig.tight_layout()
@@ -153,9 +153,9 @@ def plot_pdr_comparison(
 
     ax.set_xticks(indices)
     ax.set_xticklabels([f"Class {name}" for name in classes])
+    ax.set_xlabel("LoRaWAN class")
     ax.set_ylabel("Delivery ratio (%)")
     ax.set_ylim(0, 105)
-    ax.set_title("Uplink vs downlink packet delivery ratio")
     ax.grid(True, axis="y", linestyle="--", linewidth=0.5, alpha=0.6)
     ax.legend()
     fig.tight_layout()

--- a/scripts/mne3sd/article_a/plots/plot_class_load_results.py
+++ b/scripts/mne3sd/article_a/plots/plot_class_load_results.py
@@ -88,7 +88,6 @@ def plot_energy_by_interval(df: pd.DataFrame) -> None:
 
     ax.set_xlabel("Reporting interval (s)")
     ax.set_ylabel("Average energy per node (J)")
-    ax.set_title("Average energy consumption per class")
     ax.legend(title="Class")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
     fig.tight_layout()
@@ -127,7 +126,6 @@ def plot_pdr_by_interval(df: pd.DataFrame) -> None:
 
     ax.set_xlabel("Reporting interval (s)")
     ax.set_ylabel("PDR (%)")
-    ax.set_title("Packet delivery ratio per class")
     ax.set_ylim(0, 105)
     ax.legend(title="Class")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)

--- a/scripts/mne3sd/article_a/plots/plot_energy_duty_cycle.py
+++ b/scripts/mne3sd/article_a/plots/plot_energy_duty_cycle.py
@@ -131,7 +131,6 @@ def plot_energy_per_node_vs_duty_cycle(df: pd.DataFrame, figures_base: Path) -> 
 
     ax.set_xlabel("Duty cycle (%)")
     ax.set_ylabel("Energy per node (J)")
-    ax.set_title("Average energy per node")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.6)
     ax.legend(title="Class")
     fig.tight_layout()
@@ -165,7 +164,6 @@ def plot_pdr_vs_duty_cycle(df: pd.DataFrame, figures_base: Path) -> None:
 
     ax.set_xlabel("Duty cycle (%)")
     ax.set_ylabel("Packet delivery ratio (%)")
-    ax.set_title("Transmission reliability")
     ax.set_ylim(0, 105)
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.6)
     ax.legend(title="Class")
@@ -203,7 +201,7 @@ def plot_energy_breakdown(df: pd.DataFrame, figures_base: Path) -> None:
     ax.set_xticks(list(x))
     ax.set_xticklabels(labels, rotation=45, ha="right")
     ax.set_ylabel("Energy per node (J)")
-    ax.set_title("Energy breakdown by class and duty cycle")
+    ax.set_xlabel("LoRaWAN class and duty cycle")
     ax.legend(title="Component")
     ax.grid(True, axis="y", linestyle="--", linewidth=0.5, alpha=0.6)
     fig.tight_layout()

--- a/scripts/mne3sd/article_a/plots/plot_pdr_density_metrics.py
+++ b/scripts/mne3sd/article_a/plots/plot_pdr_density_metrics.py
@@ -152,7 +152,6 @@ def plot_pdr(summary: pd.DataFrame, *, figures_dir: Path | None) -> None:
 
     ax.set_xlabel("Gateway density (gateways/km²)")
     ax.set_ylabel("Packet delivery ratio (%)")
-    ax.set_title("Packet delivery ratio versus gateway density")
     ax.set_ylim(0, 105)
     ax.legend(title="Configuration")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
@@ -196,7 +195,6 @@ def plot_delay(summary: pd.DataFrame, *, figures_dir: Path | None) -> bool:
 
     ax.set_xlabel("Gateway density (gateways/km²)")
     ax.set_ylabel("Average delay (s)")
-    ax.set_title("Average delay versus gateway density")
     ax.legend(title="Configuration")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
     fig.tight_layout()
@@ -240,7 +238,6 @@ def plot_energy(summary: pd.DataFrame, *, figures_dir: Path | None) -> bool:
 
     ax.set_xlabel("Gateway density (gateways/km²)")
     ax.set_ylabel("Energy per node (J)")
-    ax.set_title("Energy consumption versus gateway density")
     ax.legend(title="Configuration")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
     fig.tight_layout()

--- a/scripts/mne3sd/article_a/plots/plot_pdr_load_metrics.py
+++ b/scripts/mne3sd/article_a/plots/plot_pdr_load_metrics.py
@@ -169,7 +169,6 @@ def plot_pdr(summary: pd.DataFrame, *, figures_dir: Path | None) -> None:
 
     ax.set_xlabel("Reporting interval (s)")
     ax.set_ylabel("Packet delivery ratio (%)")
-    ax.set_title("Packet delivery ratio versus reporting interval")
     ax.set_ylim(0, 105)
     ax.legend(title="Configuration")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
@@ -216,7 +215,6 @@ def plot_delay(summary: pd.DataFrame, *, figures_dir: Path | None) -> bool:
 
     ax.set_xlabel("Reporting interval (s)")
     ax.set_ylabel("Average delay (s)")
-    ax.set_title("Average delay versus reporting interval")
     ax.legend(title="Configuration")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
     fig.tight_layout()
@@ -263,7 +261,6 @@ def plot_energy(summary: pd.DataFrame, *, figures_dir: Path | None) -> bool:
 
     ax.set_xlabel("Reporting interval (s)")
     ax.set_ylabel("Energy per node (J)")
-    ax.set_title("Energy consumption versus reporting interval")
     ax.legend(title="Configuration")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
     fig.tight_layout()


### PR DESCRIPTION
## Summary
- remove explicit figure titles from the article A plotting scripts to standardise figure styling
- add x-axis labels on class comparison bar charts so the context remains clear without titles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc3470fc2c8331b412c892aa75f487