### PR TITLE
Remove plot titles from mobility metrics figures

### DIFF
--- a/scripts/mne3sd/article_b/plots/plot_mobility_gateway_metrics.py
+++ b/scripts/mne3sd/article_b/plots/plot_mobility_gateway_metrics.py
@@ -160,11 +160,11 @@ def plot_pdr_distribution_by_gateway(df: pd.DataFrame) -> None:
         bottoms = [bottom + height for bottom, height in zip(bottoms, heights)]
 
     ax.set_xticks(list(indices), [entry["label"] for entry in entries], rotation=30, ha="right")
+    ax.set_xlabel("Mobility model and gateway count")
     ax.set_ylabel("PDR share (%)")
-    ax.set_title("PDR distribution by gateway")
     ax.set_ylim(0, 100)
     ax.grid(True, axis="y", linestyle="--", linewidth=0.5, alpha=0.7)
-    ax.legend(title="Gateways")
+    ax.legend(title="Gateway (share of deliveries)")
     fig.tight_layout()
 
     output_dir = prepare_figure_directory(
@@ -193,9 +193,8 @@ def plot_downlink_delay_vs_gateways(df: pd.DataFrame) -> None:
 
     ax.set_xlabel("Number of gateways")
     ax.set_ylabel("Average downlink delay (s)")
-    ax.set_title("Impact of the number of gateways on downlink delay")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
-    ax.legend()
+    ax.legend(title="Mobility model")
     fig.tight_layout()
 
     output_dir = prepare_figure_directory(
@@ -232,9 +231,8 @@ def plot_model_comparison(df: pd.DataFrame) -> None:
 
     ax.set_xlabel("Aggregated PDR (%)")
     ax.set_ylabel("Average downlink delay (s)")
-    ax.set_title("RandomWaypoint vs Smooth comparison")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
-    ax.legend()
+    ax.legend(title="Mobility model")
     fig.tight_layout()
 
     output_dir = prepare_figure_directory(

--- a/scripts/mne3sd/article_b/plots/plot_mobility_range_metrics.py
+++ b/scripts/mne3sd/article_b/plots/plot_mobility_range_metrics.py
@@ -132,11 +132,10 @@ def plot_pdr_vs_range(
                 highlight_label_added = True
 
     ax.set_xlabel("Communication range (km)")
-    ax.set_ylabel("PDR (%)")
-    ax.set_title("PDR versus communication range")
+    ax.set_ylabel("Aggregated PDR (%)")
     ax.set_ylim(0, 105)
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
-    ax.legend()
+    ax.legend(title="Mobility model")
     fig.tight_layout()
 
     output_dir = prepare_figure_directory(
@@ -163,9 +162,8 @@ def plot_delay_vs_range(df: pd.DataFrame) -> None:
 
     ax.set_xlabel("Communication range (km)")
     ax.set_ylabel("Average delay (s)")
-    ax.set_title("Average delay versus communication range")
     ax.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
-    ax.legend()
+    ax.legend(title="Mobility model")
     fig.tight_layout()
 
     output_dir = prepare_figure_directory(

--- a/scripts/mne3sd/article_b/plots/plot_mobility_speed_metrics.py
+++ b/scripts/mne3sd/article_b/plots/plot_mobility_speed_metrics.py
@@ -155,7 +155,6 @@ def plot_grouped_bars(
     df: pd.DataFrame,
     value_column: str,
     ylabel: str,
-    title: str,
     output_name: str,
     dpi: int,
     value_format: str,
@@ -177,9 +176,8 @@ def plot_grouped_bars(
     fig, ax = plt.subplots(figsize=(fig_width, 2.6))
 
     pivot.plot(kind="bar", ax=ax, width=0.75)
-    ax.set_xlabel("Speed profile")
+    ax.set_xlabel("Speed profile (grouped by mobility model)")
     ax.set_ylabel(ylabel)
-    ax.set_title(title)
     if ylim is not None:
         ax.set_ylim(*ylim)
     ax.grid(axis="y", linestyle="--", linewidth=0.5, alpha=0.7)
@@ -226,8 +224,7 @@ def plot_heatmap(df: pd.DataFrame, output_name: str, dpi: int) -> None:
     ax.set_xlabel("Communication range (km)")
     ax.set_yticks(range(len(pivot.index)))
     ax.set_yticklabels(pivot.index)
-    ax.set_ylabel("Speed profile")
-    ax.set_title("PDR by speed profile and range")
+    ax.set_ylabel("Speed profile (rows)")
 
     for y, profile in enumerate(pivot.index):
         for x, rng in enumerate(pivot.columns):
@@ -273,8 +270,7 @@ def main() -> None:  # pragma: no cover - CLI entry point
     plot_grouped_bars(
         metrics,
         "pdr_percent",
-        pdr_label,
-        "PDR by speed profile",
+        f"{pdr_label} by speed profile",
         "pdr_by_speed_profile",
         args.dpi,
         pdr_format,
@@ -284,8 +280,7 @@ def main() -> None:  # pragma: no cover - CLI entry point
     plot_grouped_bars(
         metrics,
         "avg_delay_s_value",
-        "Average delay (s)",
-        "Average delay by speed profile",
+        "Average delay (s) by speed profile",
         "average_delay_by_speed_profile",
         args.dpi,
         "{:.2f}",


### PR DESCRIPTION
## Summary
- replace the mobility gateway titles with explanatory axis labels and legend titles so the charts remain self-explanatory without figure titles
- update the mobility range plots to rely on contextual axis labels and a legend title rather than set_title
- adjust the speed metrics plotting helper and heatmap labelling to convey context through axes while removing per-axis titles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc35a7c480833188894af610865301