### PR TITLE
Handle class A scheduling rejections

### DIFF
--- a/tests/test_adr.py
+++ b/tests/test_adr.py
@@ -41,3 +41,66 @@ def test_adr_increases_sf_with_poor_link():
     node = _run(distance=10000.0, initial_sf=8)
     assert node.sf == 7
     assert node.tx_power == TX_POWER_INDEX_TO_DBM[3]
+
+
+def test_adr_recovers_after_rx2_rejection():
+    from loraflexsim.launcher.lorawan import LinkADRReq, compute_rx2, SF_TO_DR
+
+    ch = Channel(shadowing_std=0.0, fast_fading_std=0.0, noise_floor_std=0.0)
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        transmission_mode="Periodic",
+        packet_interval=1.0,
+        packets_to_send=0,
+        mobility=False,
+        adr_server=True,
+        adr_method="avg",
+        channels=[ch],
+        seed=1,
+    )
+    apply_adr(sim)
+    node = sim.nodes[0]
+    gw = sim.gateways[0]
+    scheduler = sim.network_server.scheduler
+    node.security_enabled = False
+    node.sf = 12
+    node.last_uplink_end_time = 0.0
+
+    rx2 = compute_rx2(node.last_uplink_end_time, node.rx_delay)
+    scheduler._gateway_busy[gw.id] = rx2 + 1.0
+
+    initial_pending = node.downlink_pending
+    initial_fcnt = node.fcnt_down
+    frames_before = node.frames_since_last_adr_command
+
+    sim.network_server.send_downlink(
+        node,
+        adr_command=(7, node.tx_power, node.chmask, node.nb_trans),
+        gateway=gw,
+    )
+
+    assert node.downlink_pending == initial_pending
+    assert scheduler.next_time(node.id) is None
+    assert node.fcnt_down == initial_fcnt
+    assert node.frames_since_last_adr_command == frames_before
+
+    scheduler._gateway_busy[gw.id] = 0.0
+    sim.network_server.send_downlink(
+        node,
+        adr_command=(7, node.tx_power, node.chmask, node.nb_trans),
+        gateway=gw,
+    )
+
+    scheduled_time = scheduler.next_time(node.id)
+    assert scheduled_time is not None
+    assert node.downlink_pending == initial_pending + 1
+
+    entry = scheduler.pop_ready(node.id, scheduled_time)
+    assert entry is not None
+    req = LinkADRReq.from_bytes(entry.frame.payload[:5])
+    assert req.datarate == SF_TO_DR[7]
+
+    node.handle_downlink(entry.frame)
+    assert node.sf == 7
+    assert node.downlink_pending == initial_pending

--- a/tests/test_class_a.py
+++ b/tests/test_class_a.py
@@ -29,6 +29,16 @@ def test_schedule_class_a_after_delay():
     assert entry and entry.frame == b"b" and entry.gateway is gw
 
 
+def test_schedule_class_a_rejects_after_rx2():
+    scheduler = DownlinkScheduler()
+    gw = Gateway(1, 0, 0)
+    node = Node(1, 0.0, 0.0, 7, 14)
+    scheduler._gateway_busy[gw.id] = 3.0
+    t = scheduler.schedule_class_a(node, 0.0, 1.0, 2.0, b"c", gw)
+    assert t is None
+    assert scheduler.pop_ready(node.id, 10.0) is None
+
+
 def test_downlink_with_server_delays():
     sim = SimpleNamespace(current_time=0.0, event_queue=[], event_id_counter=0)
     server = NetworkServer(simulator=sim, process_delay=1.0, network_delay=1.0)


### PR DESCRIPTION
## Summary
- reject Class A downlink attempts when the second RX window is exceeded and log the outcome
- prevent `send_downlink` from leaving stale counters when scheduling fails and ensure retries still schedule correctly
- add regression coverage for Class A rejection handling and ADR recovery after a forced RX2 conflict

## Testing
- `pytest tests/test_class_a.py tests/test_adr.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd114b96608331a2a9ea085e3affd3