### PR TITLE
Adjust grouped bar legend layout

### DIFF
--- a/scripts/mne3sd/article_b/plots/plot_mobility_speed_metrics.py
+++ b/scripts/mne3sd/article_b/plots/plot_mobility_speed_metrics.py
@@ -206,8 +206,7 @@ def plot_grouped_bars(
     for container in containers:
         ax.bar_label(container, fmt=value_format, padding=2, fontsize=7)
 
-    fig.subplots_adjust(right=0.8)
-    fig.tight_layout()
+    fig.tight_layout(rect=(0, 0, 0.82, 1))
     output_dir = prepare_figure_directory(
         article=ARTICLE,
         scenario=SCENARIO,


### PR DESCRIPTION
## Summary
- reserve additional figure space so the grouped bar legend remains visible when exported

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd4e6389508331899ae4f596b2fd84