### PR TITLE
Allow overriding mobility sweep result file paths

### DIFF
--- a/scripts/mne3sd/article_b/README.md
+++ b/scripts/mne3sd/article_b/README.md
@@ -68,6 +68,13 @@ Les lanceurs de scénarios respectent l'option `--profile` partagée ainsi que l
 ### Parallélisation des réplicats
 Les scripts `run_mobility_range_sweep.py`, `run_mobility_speed_sweep.py` et `run_mobility_gateway_sweep.py` acceptent un paramètre commun `--workers` (par défaut `1`) pour répartir les réplicats Monte Carlo sur plusieurs processus. Les résultats agrégés restent triés de manière déterministe quel que soit le nombre de workers, ce qui facilite la comparaison entre exécutions. En dehors des traitements lourds, conservez la valeur par défaut pour éviter un surcoût d'initialisation. Pour des vérifications rapides sous Windows 11 ou dans un pipeline CI, combinez `--workers 1` avec `--profile ci` afin de bénéficier des paramètres allégés documentés ci-dessus.
 
+Chaque sweep expose également `--results` pour définir explicitement le chemin du CSV généré. Cela permet de séparer les différentes séries d'expériences sans devoir renommer les fichiers a posteriori, par exemple :
+
+```
+python -m scripts.mne3sd.article_b.scenarios.run_mobility_speed_sweep \
+    --profile fast --workers 4 --results results/mne3sd/article_b/mobility_speed_fast.csv
+```
+
 ## Structure du répertoire
 
 ```
@@ -109,6 +116,10 @@ python -m scripts.mne3sd.article_b.scenarios.<scenario_module> \
     --duration 7200 \
     --seed 123 \
     --output results/mne3sd/article_b/<scenario_name>.csv
+
+python -m scripts.mne3sd.article_b.scenarios.run_mobility_range_sweep \
+    --replicates 5 --seed 321 \
+    --results results/mne3sd/article_b/mobility_range_custom.csv
 ```
 
 Pour balayer différentes plages de distance ou de vitesse, utilisez `--distance-min`, `--distance-max`, `--speed-min` et `--speed-max`. Les modules de scénario peuvent proposer des options additionnelles (par exemple `--handover-threshold` dans `rural_highway`). Consultez la docstring pour les détails.

--- a/scripts/mne3sd/article_b/scenarios/run_mobility_gateway_sweep.py
+++ b/scripts/mne3sd/article_b/scenarios/run_mobility_gateway_sweep.py
@@ -18,7 +18,8 @@ exploratory runs.
 Example usage::
 
     python scripts/mne3sd/article_b/scenarios/run_mobility_gateway_sweep.py \
-        --gateways-list 1,2,4 --nodes 200 --replicates 10 --seed 42
+        --gateways-list 1,2,4 --nodes 200 --replicates 10 --seed 42 \
+        --results results/mne3sd/article_b/mobility_gateway_metrics_custom.csv
 """
 
 from __future__ import annotations
@@ -371,10 +372,19 @@ def main() -> None:  # noqa: D401 - CLI entry point
         action="store_true",
         help="Skip simulations that already exist in the detailed CSV",
     )
+    parser.add_argument(
+        "--results",
+        type=Path,
+        default=RESULTS_PATH,
+        help=(
+            "Destination CSV for the sweep results. Defaults to %(default)s."
+        ),
+    )
     add_worker_argument(parser, default="auto")
     add_execution_profile_argument(parser)
     args = parser.parse_args()
 
+    results_path = Path(args.results)
     profile = resolve_execution_profile(args.profile)
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -455,10 +465,10 @@ def main() -> None:  # noqa: D401 - CLI entry point
                     for replicate in range(1, replicates + 1)
                 ]
 
-                if args.resume and RESULTS_PATH.exists():
+                if args.resume and results_path.exists():
                     original_count = len(tasks)
                     tasks = filter_completed_tasks(
-                        RESULTS_PATH, ("model", "gateways", "replicate"), tasks
+                        results_path, ("model", "gateways", "replicate"), tasks
                     )
                     skipped = original_count - len(tasks)
                     LOGGER.info(
@@ -529,9 +539,9 @@ def main() -> None:  # noqa: D401 - CLI entry point
         if executor is not None:
             executor.shutdown()
 
-    write_csv(RESULTS_PATH, FIELDNAMES, results)
+    write_csv(results_path, FIELDNAMES, results)
 
-    print(f"Results saved to {RESULTS_PATH}")
+    print(f"Results saved to {results_path}")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/scripts/mne3sd/article_b/scenarios/run_mobility_range_sweep.py
+++ b/scripts/mne3sd/article_b/scenarios/run_mobility_range_sweep.py
@@ -16,7 +16,8 @@ Use ``--profile fast`` to constrain the sweep to two range values (5 and 10 km)
 Example usage::
 
     python scripts/mne3sd/article_b/scenarios/run_mobility_range_sweep.py \
-        --nodes 200 --packets 50 --replicates 10 --seed 42
+        --nodes 200 --packets 50 --replicates 10 --seed 42 \
+        --results results/mne3sd/article_b/mobility_range_metrics_custom.csv
 """
 
 from __future__ import annotations
@@ -257,10 +258,19 @@ def main() -> None:  # noqa: D401 - CLI entry point
         action="store_true",
         help="Skip simulations that already exist in the detailed CSV",
     )
+    parser.add_argument(
+        "--results",
+        type=Path,
+        default=RESULTS_PATH,
+        help=(
+            "Destination CSV for the sweep results. Defaults to %(default)s."
+        ),
+    )
     add_worker_argument(parser, default="auto")
     add_execution_profile_argument(parser)
     args = parser.parse_args()
 
+    results_path = Path(args.results)
     profile = resolve_execution_profile(args.profile)
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -336,10 +346,10 @@ def main() -> None:  # noqa: D401 - CLI entry point
                     for replicate in range(1, replicates + 1)
                 ]
 
-                if args.resume and RESULTS_PATH.exists():
+                if args.resume and results_path.exists():
                     original_count = len(tasks)
                     tasks = filter_completed_tasks(
-                        RESULTS_PATH, ("model", "range_km", "replicate"), tasks
+                        results_path, ("model", "range_km", "replicate"), tasks
                     )
                     skipped = original_count - len(tasks)
                     LOGGER.info(
@@ -393,9 +403,9 @@ def main() -> None:  # noqa: D401 - CLI entry point
         if executor is not None:
             executor.shutdown()
 
-    write_csv(RESULTS_PATH, FIELDNAMES, results)
+    write_csv(results_path, FIELDNAMES, results)
 
-    print(f"Results saved to {RESULTS_PATH}")
+    print(f"Results saved to {results_path}")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/scripts/mne3sd/article_b/scenarios/run_mobility_speed_sweep.py
+++ b/scripts/mne3sd/article_b/scenarios/run_mobility_speed_sweep.py
@@ -20,7 +20,8 @@ Example usage::
     python scripts/mne3sd/article_b/scenarios/run_mobility_speed_sweep.py \
         --nodes 200 --replicates 10 --seed 42 \
         --speed-profiles "pedestrian: (0.5, 1.5)" \
-        --speed-profiles "urban: (1.5, 3.5)"
+        --speed-profiles "urban: (1.5, 3.5)" \
+        --results results/mne3sd/article_b/mobility_speed_metrics_custom.csv
 """
 
 from __future__ import annotations
@@ -269,10 +270,19 @@ def main() -> None:  # noqa: D401 - CLI entry point
         action="store_true",
         help="Skip simulations that already exist in the detailed CSV",
     )
+    parser.add_argument(
+        "--results",
+        type=Path,
+        default=RESULTS_PATH,
+        help=(
+            "Destination CSV for the sweep results. Defaults to %(default)s."
+        ),
+    )
     add_worker_argument(parser, default="auto")
     add_execution_profile_argument(parser)
     args = parser.parse_args()
 
+    results_path = Path(args.results)
     profile = resolve_execution_profile(args.profile)
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -362,10 +372,10 @@ def main() -> None:  # noqa: D401 - CLI entry point
                     for replicate in range(1, replicates + 1)
                 ]
 
-                if args.resume and RESULTS_PATH.exists():
+                if args.resume and results_path.exists():
                     original_count = len(tasks)
                     tasks = filter_completed_tasks(
-                        RESULTS_PATH, ("model", "speed_profile", "replicate"), tasks
+                        results_path, ("model", "speed_profile", "replicate"), tasks
                     )
                     skipped = original_count - len(tasks)
                     LOGGER.info(
@@ -409,9 +419,9 @@ def main() -> None:  # noqa: D401 - CLI entry point
         if executor is not None:
             executor.shutdown()
 
-    write_csv(RESULTS_PATH, FIELDNAMES, results)
+    write_csv(results_path, FIELDNAMES, results)
 
-    print(f"Results saved to {RESULTS_PATH}")
+    print(f"Results saved to {results_path}")
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/scripts/run_ci_pipeline.sh
+++ b/scripts/run_ci_pipeline.sh
@@ -55,34 +55,30 @@ run_density_sweep_adr() {
 run_range_sweep() {
   local nodes=$1
   log "Article B – mobility range sweep (${nodes} nodes, profile ${PROFILE})"
+  local target="${ROOT_DIR}/results/mne3sd/article_b/mobility_range_metrics_nodes_${nodes}.csv"
   "${PYTHON_BIN}" -m scripts.mne3sd.article_b.scenarios.run_mobility_range_sweep \
     --nodes "${nodes}" \
     --profile "${PROFILE}" \
-    --seed $((80 + nodes))
-  local output="${ROOT_DIR}/results/mne3sd/article_b/mobility_range_metrics.csv"
-  local target="${ROOT_DIR}/results/mne3sd/article_b/mobility_range_metrics_nodes_${nodes}.csv"
-  if [[ -f "${output}" ]]; then
-    mv -f "${output}" "${target}"
-  else
-    log "Warning: expected mobility range metrics at ${output} not found"
+    --seed $((80 + nodes)) \
+    --results "${target}"
+  if [[ ! -f "${target}" ]]; then
+    log "Warning: expected mobility range metrics at ${target} not found"
   fi
 }
 
 run_range_sweep_adr() {
   local nodes=$1
   log "Article B – ADR sensitivity (${nodes} nodes)"
+  local target="${ROOT_DIR}/results/mne3sd/article_b/mobility_range_metrics_adr_nodes_${nodes}.csv"
   "${PYTHON_BIN}" -m scripts.mne3sd.article_b.scenarios.run_mobility_range_sweep \
     --nodes "${nodes}" \
     --profile "${PROFILE}" \
     --adr-node \
     --adr-server \
-    --seed $((180 + nodes))
-  local output="${ROOT_DIR}/results/mne3sd/article_b/mobility_range_metrics.csv"
-  local target="${ROOT_DIR}/results/mne3sd/article_b/mobility_range_metrics_adr_nodes_${nodes}.csv"
-  if [[ -f "${output}" ]]; then
-    mv -f "${output}" "${target}"
-  else
-    log "Warning: expected ADR mobility metrics at ${output} not found"
+    --seed $((180 + nodes)) \
+    --results "${target}"
+  if [[ ! -f "${target}" ]]; then
+    log "Warning: expected ADR mobility metrics at ${target} not found"
   fi
 }
 


### PR DESCRIPTION
## Summary
- add a `--results` CLI argument to the mobility sweep scenarios and feed it into the resume logic
- document the new option in the Article B README and update example commands to show custom file names
- teach the CI helper to write sweep outputs directly to their final targets

## Testing
- python -m compileall scripts/mne3sd/article_b/scenarios

------
https://chatgpt.com/codex/tasks/task_e_68dd50687e548331b1c69f0e162941a7